### PR TITLE
Making the EOF loop run

### DIFF
--- a/docs/03-compute-resources.md
+++ b/docs/03-compute-resources.md
@@ -314,7 +314,7 @@ for instance in controller-0 controller-1 controller-2 worker-0 worker-1 worker-
   HostName ${EXTERNAL_IP}
   IdentityFile ~/.ssh/id_rsa
   ServerAliveInterval 120
-  EOF
+EOF
 done
 ```
 


### PR DESCRIPTION
My shell (ZSH) wasn't able to run this `for` loop as written. I received the following error until I made the proposed change:

```
warning: here-document at line 5 delimited by end-of-file (wanted `EOF')
syntax error: unexpected end of file
```