### PR TITLE
Controller fixes

### DIFF
--- a/docs/04-certificate-authority.md
+++ b/docs/04-certificate-authority.md
@@ -282,6 +282,9 @@ Generate the Kubernetes API Server certificate and private key:
 ```
 KUBERNETES_PUBLIC_ADDRESS=$(az network public-ip show -g k8s-the-hard-way -n k8s-the-hard-way-ip --query ipAddress --output tsv)
 
+KUBERNETES_HOSTNAMES=kubernetes,kubernetes.default,kubernetes.default.svc,kubernetes.default.svc.cluster,kubernetes.svc.cluster.local
+
+
 cat > kubernetes-csr.json <<EOF
 {
   "CN": "kubernetes",
@@ -306,7 +309,7 @@ cfssl gencert \
   -ca=ca.pem \
   -ca-key=ca-key.pem \
   -config=ca-config.json \
-  -hostname=10.32.0.1,10.240.0.10,10.240.0.11,10.240.0.12,${KUBERNETES_PUBLIC_ADDRESS},127.0.0.1,kubernetes.default \
+  -hostname=10.32.0.1,10.240.0.10,10.240.0.11,10.240.0.12,${KUBERNETES_PUBLIC_ADDRESS},127.0.0.1,${KUBERNETES_HOSTNAMES} \
   -profile=kubernetes \
   kubernetes-csr.json | cfssljson -bare kubernetes
 ```

--- a/docs/08-bootstrapping-kubernetes-controllers.md
+++ b/docs/08-bootstrapping-kubernetes-controllers.md
@@ -344,11 +344,6 @@ EOF
 ### Verification
 
 Note: run this on the base local machine
-<!-- Install azure CLI
-```
-curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
-az login
-``` -->
 
 Retrieve the `kubernetes-the-hard-way` static IP address:
 

--- a/docs/08-bootstrapping-kubernetes-controllers.md
+++ b/docs/08-bootstrapping-kubernetes-controllers.md
@@ -57,12 +57,10 @@ The instance internal IP address will be used to advertise the API Server to mem
 INTERNAL_IP=$(curl -H Metadata:true "http://169.254.169.254/metadata/instance/network/interface/0/ipv4/ipAddress/0/privateIpAddress?api-version=2017-08-01&format=text")
 
 
-KUBERNETES_PUBLIC_ADDRESS=$(curl -H Metadata:true "http://169.254.169.254/metadata/instance/network/interface/0/ipv4/ipAddress/0/publicIpAddress?api-version=2017-08-01&format=text")
-
-
+KUBERNETES_PUBLIC_ADDRESS=$(az network public-ip show -g k8s-the-hard-way -n k8s-the-hard-way-ip --query ipAddress --output tsv)
 
 ```
-KUBERNETES_PUBLIC_ADDRESS=$(az network public-ip show -g k8s-the-hard-way -n k8s-the-hard-way-ip --query ipAddress --output tsv)
+TODO: figure out the best way to get KUBERNETES_PUBLIC_ADDRESS
 
 Create the `kube-apiserver.service` systemd unit file:
 

--- a/docs/09-bootstrapping-kubernetes-workers.md
+++ b/docs/09-bootstrapping-kubernetes-workers.md
@@ -29,14 +29,14 @@ sudo apt-get -y install socat conntrack ipset
 
 ```
 wget -q --show-progress --https-only --timestamping \
-  https://github.com/kubernetes-sigs/cri-tools/releases/download/v1.12.0/crictl-v1.12.0-linux-amd64.tar.gz \
+  https://github.com/kubernetes-sigs/cri-tools/releases/download/v1.24.0/crictl-v1.24.0-linux-amd64.tar.gz \
   https://storage.googleapis.com/kubernetes-the-hard-way/runsc-50c283b9f56bb7200938d9e207355f05f79f0d17 \
-  https://github.com/opencontainers/runc/releases/download/v1.0.0-rc5/runc.amd64 \
-  https://github.com/containernetworking/plugins/releases/download/v0.6.0/cni-plugins-amd64-v0.6.0.tgz \
-  https://github.com/containerd/containerd/releases/download/v1.2.0-rc.0/containerd-1.2.0-rc.0.linux-amd64.tar.gz \
-  https://storage.googleapis.com/kubernetes-release/release/v1.12.0/bin/linux/amd64/kubectl \
-  https://storage.googleapis.com/kubernetes-release/release/v1.12.0/bin/linux/amd64/kube-proxy \
-  https://storage.googleapis.com/kubernetes-release/release/v1.12.0/bin/linux/amd64/kubelet
+  https://github.com/opencontainers/runc/releases/download/v1.0.0-rc93/runc.amd64 \
+  https://github.com/containernetworking/plugins/releases/download/v0.9.1/cni-plugins-linux-amd64-v0.9.1.tgz \
+  https://github.com/containerd/containerd/releases/download/v1.4.4/containerd-1.4.4-linux-amd64.tar.gz \
+  https://storage.googleapis.com/kubernetes-release/release/v1.24.0/bin/linux/amd64/kubectl \
+  https://storage.googleapis.com/kubernetes-release/release/v1.24.0/bin/linux/amd64/kube-proxy \
+  https://storage.googleapis.com/kubernetes-release/release/v1.24.0/bin/linux/amd64/kubelet
 ```
 
 Create the installation directories:
@@ -54,13 +54,13 @@ sudo mkdir -p \
 Install the worker binaries:
 
 ```
-  sudo mv runsc-50c283b9f56bb7200938d9e207355f05f79f0d17 runsc
-  sudo mv runc.amd64 runc
-  chmod +x kubectl kube-proxy kubelet runc runsc
-  sudo mv kubectl kube-proxy kubelet runc runsc /usr/local/bin/
-  sudo tar -xvf crictl-v1.12.0-linux-amd64.tar.gz -C /usr/local/bin/
-  sudo tar -xvf cni-plugins-amd64-v0.6.0.tgz -C /opt/cni/bin/
-  sudo tar -xvf containerd-1.2.0-rc.0.linux-amd64.tar.gz -C /
+sudo mv runsc-50c283b9f56bb7200938d9e207355f05f79f0d17 runsc
+sudo mv runc.amd64 runc
+chmod +x kubectl kube-proxy kubelet runc runsc
+sudo mv kubectl kube-proxy kubelet runc runsc /usr/local/bin/
+sudo tar -xvf crictl-v1.24.0-linux-amd64.tar.gz -C /usr/local/bin/
+sudo tar -xvf cni-plugins-linux-amd64-v0.9.1.tgz -C /opt/cni/bin/
+sudo tar -xvf containerd-1.4.4-linux-amd64.tar.gz -C /
 ```
 
 ### Configure CNI Networking
@@ -209,11 +209,8 @@ Requires=containerd.service
 [Service]
 ExecStart=/usr/local/bin/kubelet \\
   --config=/var/lib/kubelet/kubelet-config.yaml \\
-  --container-runtime=remote \\
   --container-runtime-endpoint=unix:///var/run/containerd/containerd.sock \\
-  --image-pull-progress-deadline=2m \\
   --kubeconfig=/var/lib/kubelet/kubeconfig \\
-  --network-plugin=cni \\
   --register-node=true \\
   --v=2
 Restart=on-failure

--- a/docs/10-configuring-kubectl.md
+++ b/docs/10-configuring-kubectl.md
@@ -11,9 +11,9 @@ Each kubeconfig requires a Kubernetes API Server to connect to. To support high 
 Generate a kubeconfig file suitable for authenticating as the `admin` user:
 
 ```
-KUBERNETES_PUBLIC_ADDRESS=$(az network public-ip show -g kubernetes-the-hard-way -n kubernetes-the-hard-way-ip --query ipAddress --output tsv)
+KUBERNETES_PUBLIC_ADDRESS=$(az network public-ip show -g k8s-the-hard-way -n k8s-the-hard-way-ip --query ipAddress --output tsv)
 
-kubectl config set-cluster kubernetes-the-hard-way \
+kubectl config set-cluster k8s-the-hard-way \
   --certificate-authority=ca.pem \
   --embed-certs=true \
   --server=https://${KUBERNETES_PUBLIC_ADDRESS}:6443
@@ -22,11 +22,11 @@ kubectl config set-credentials admin \
   --client-certificate=admin.pem \
   --client-key=admin-key.pem
 
-kubectl config set-context kubernetes-the-hard-way \
-  --cluster=kubernetes-the-hard-way \
+kubectl config set-context k8s-the-hard-way \
+  --cluster=k8s-the-hard-way \
   --user=admin
 
-kubectl config use-context kubernetes-the-hard-way
+kubectl config use-context k8s-the-hard-way
 ```
 
 ## Verification

--- a/docs/10-configuring-kubectl.md
+++ b/docs/10-configuring-kubectl.md
@@ -58,9 +58,9 @@ kubectl get nodes
 
 ```
 NAME       STATUS   ROLES    AGE    VERSION
-worker-0   Ready    <none>   117s   v1.12.0
-worker-1   Ready    <none>   118s   v1.12.0
-worker-2   Ready    <none>   118s   v1.12.0
+worker-0   Ready    <none>   117s   v1.24.0
+worker-1   Ready    <none>   118s   v1.24.0
+worker-2   Ready    <none>   118s   v1.24.0
 ```
 
 Next: [Provisioning Pod Network Routes](11-pod-network-routes.md)

--- a/docs/11-pod-network-routes.md
+++ b/docs/11-pod-network-routes.md
@@ -8,12 +8,12 @@ In this lab you will create a route for each worker node that maps the node's Po
 
 ## The Routing Table
 
-In this section you will gather the information required to create routes in the `kubernetes-the-hard-way` VPC network.
+In this section you will gather the information required to create routes in the `k8s-the-hard-way` VPC network.
 
 Create the Azure route table
 
 ```
-az network route-table create --resource-group kubernetes-the-hard-way --name kubernetes-the-hard-way-rt
+az network route-table create --resource-group k8s-the-hard-way --name k8s-the-hard-way-rt
 ```
 
 ## Routes
@@ -23,9 +23,9 @@ Create network routes for each worker instance:
 ```
 for i in 0 1 2; do
   az network route-table route create \
-    --resource-group kubernetes-the-hard-way \
-    --name kubernetes-the-hard-way-route-10-200-${i}-0-24 \
-    --route-table-name kubernetes-the-hard-way-rt \
+    --resource-group k8s-the-hard-way \
+    --name k8s-the-hard-way-route-10-200-${i}-0-24 \
+    --route-table-name k8s-the-hard-way-rt \
     --next-hop-type VirtualAppliance \
     --next-hop-ip-address 10.240.0.2${i} \
     --address-prefix 10.200.${i}.0/24
@@ -33,16 +33,16 @@ done
 ```
 ```
 az network vnet subnet update \
-  --resource-group kubernetes-the-hard-way \
-  --vnet-name kubernetes-the-hard-way-vnet \
-  --name kubernetes-the-hard-way-subnet \
-  --route-table kubernetes-the-hard-way-rt
+  --resource-group k8s-the-hard-way \
+  --vnet-name k8s-the-hard-way-vnet \
+  --name k8s-the-hard-way-subnet \
+  --route-table k8s-the-hard-way-rt
 ```
 
-List the routes in the `kubernetes-the-hard-way` VPC network:
+List the routes in the `k8s-the-hard-way` VPC network:
 
 ```
-az network route-table route list --resource-group kubernetes-the-hard-way --route-table-name kubernetes-the-hard-way-rt -o table
+az network route-table route list --resource-group k8s-the-hard-way --route-table-name k8s-the-hard-way-rt -o table
 ```
 
 > output
@@ -50,9 +50,9 @@ az network route-table route list --resource-group kubernetes-the-hard-way --rou
 ```
 AddressPrefix    Name                                         NextHopIpAddress    NextHopType       ProvisioningState    ResourceGroup
 ---------------  -------------------------------------------  ------------------  ----------------  -------------------  -----------------------
-10.200.0.0/24    kubernetes-the-hard-way-route-10-200-0-0-24  10.240.0.20         VirtualAppliance  Succeeded            kubernetes-the-hard-way
-10.200.1.0/24    kubernetes-the-hard-way-route-10-200-1-0-24  10.240.0.21         VirtualAppliance  Succeeded            kubernetes-the-hard-way
-10.200.2.0/24    kubernetes-the-hard-way-route-10-200-2-0-24  10.240.0.22         VirtualAppliance  Succeeded            kubernetes-the-hard-way
+10.200.0.0/24    k8s-the-hard-way-route-10-200-0-0-24  10.240.0.20         VirtualAppliance  Succeeded            k8s-the-hard-way
+10.200.1.0/24    k8s-the-hard-way-route-10-200-1-0-24  10.240.0.21         VirtualAppliance  Succeeded            k8s-the-hard-way
+10.200.2.0/24    k8s-the-hard-way-route-10-200-2-0-24  10.240.0.22         VirtualAppliance  Succeeded            k8s-the-hard-way
 ```
 
 Next: [Deploying the DNS Cluster Add-on](12-dns-addon.md)

--- a/docs/11-pod-network-routes.md
+++ b/docs/11-pod-network-routes.md
@@ -48,11 +48,11 @@ az network route-table route list --resource-group k8s-the-hard-way --route-tabl
 > output
 
 ```
-AddressPrefix    Name                                         NextHopIpAddress    NextHopType       ProvisioningState    ResourceGroup
----------------  -------------------------------------------  ------------------  ----------------  -------------------  -----------------------
-10.200.0.0/24    k8s-the-hard-way-route-10-200-0-0-24  10.240.0.20         VirtualAppliance  Succeeded            k8s-the-hard-way
-10.200.1.0/24    k8s-the-hard-way-route-10-200-1-0-24  10.240.0.21         VirtualAppliance  Succeeded            k8s-the-hard-way
-10.200.2.0/24    k8s-the-hard-way-route-10-200-2-0-24  10.240.0.22         VirtualAppliance  Succeeded            k8s-the-hard-way
+AddressPrefix    HasBgpOverride    Name                                  NextHopIpAddress    NextHopType       ProvisioningState    ResourceGroup
+---------------  ----------------  ------------------------------------  ------------------  ----------------  -------------------  ----------------
+10.200.0.0/24    False             k8s-the-hard-way-route-10-200-0-0-24  10.240.0.20         VirtualAppliance  Succeeded            k8s-the-hard-way
+10.200.1.0/24    False             k8s-the-hard-way-route-10-200-1-0-24  10.240.0.21         VirtualAppliance  Succeeded            k8s-the-hard-way
+10.200.2.0/24    False             k8s-the-hard-way-route-10-200-2-0-24  10.240.0.22         VirtualAppliance  Succeeded            k8s-the-hard-way
 ```
 
 Next: [Deploying the DNS Cluster Add-on](12-dns-addon.md)

--- a/docs/13-smoke-test.md
+++ b/docs/13-smoke-test.md
@@ -9,11 +9,11 @@ In this section you will verify the ability to [encrypt secret data at rest](htt
 Create a generic secret:
 
 ```
-kubectl create secret generic kubernetes-the-hard-way \
+kubectl create secret generic k8s-the-hard-way \
   --from-literal="mykey=mydata"
 ```
 
-Print a hexdump of the `kubernetes-the-hard-way` secret stored in etcd:
+Print a hexdump of the `k8s-the-hard-way` secret stored in etcd:
 
 ```
 ssh controller-0
@@ -23,7 +23,7 @@ sudo ETCDCTL_API=3 etcdctl get \
   --cacert=/etc/etcd/ca.pem \
   --cert=/etc/etcd/kubernetes.pem \
   --key=/etc/etcd/kubernetes-key.pem\
-  /registry/secrets/default/kubernetes-the-hard-way | hexdump -C
+  /registry/secrets/default/k8s-the-hard-way | hexdump -C
 ```
 
 > output
@@ -56,13 +56,13 @@ In this section you will verify the ability to create and manage [Deployments](h
 Create a deployment for the [nginx](https://nginx.org/en/) web server:
 
 ```
-kubectl run nginx --image=nginx
+kubectl create deployment nginx --image=nginx
 ```
 
 List the pod created by the `nginx` deployment:
 
 ```
-kubectl get pods -l run=nginx
+kubectl get pods -l app=nginx
 ```
 
 > output
@@ -79,7 +79,7 @@ In this section you will verify the ability to access applications remotely usin
 Retrieve the full name of the `nginx` pod:
 
 ```
-POD_NAME=$(kubectl get pods -l run=nginx -o jsonpath="{.items[0].metadata.name}")
+POD_NAME=$(kubectl get pods -l app=nginx -o jsonpath="{.items[0].metadata.name}")
 ```
 
 Forward port `8080` on your local machine to port `80` of the `nginx` pod:
@@ -105,7 +105,7 @@ curl --head http://127.0.0.1:8080
 
 ```
 HTTP/1.1 200 OK
-Server: nginx/1.15.4
+Server: nginx/1.21.6
 Date: Sun, 30 Sep 2018 19:23:10 GMT
 Content-Type: text/html
 Content-Length: 612
@@ -153,7 +153,7 @@ kubectl exec -ti $POD_NAME -- nginx -v
 > output
 
 ```
-nginx version: nginx/1.15.4
+nginx version: nginx/1.21.6
 ```
 
 ## Services
@@ -179,8 +179,8 @@ Create a firewall rule that allows remote access to the `nginx` node port:
 
 ```
 az network nsg rule create \
-  --resource-group kubernetes-the-hard-way \
-  --nsg-name kubernetes-the-hard-way-nsg \
+  --resource-group k8s-the-hard-way \
+  --nsg-name k8s-the-hard-way-nsg \
   --name nginx \
   --access Allow \
   --direction Inbound \
@@ -188,13 +188,13 @@ az network nsg rule create \
   --protocol Tcp \
   --source-address-prefixes "*" \
   --source-port-range "*" \
-  --destination-port-ranges ${NODE_PORT} \
+  --destination-port-ranges ${NODE_PORT} 
 ```
 
 Retrieve the external IP address of a worker instance:
 
 ```
-EXTERNAL_IP=$(az vm show --show-details -g kubernetes-the-hard-way -n worker-0 --query publicIps --output tsv)
+EXTERNAL_IP=$(az vm show --show-details -g k8s-the-hard-way -n worker-0 --query publicIps --output tsv)
 ```
 
 Make an HTTP request using the external IP address and the `nginx` node port:
@@ -207,7 +207,7 @@ curl -I http://${EXTERNAL_IP}:${NODE_PORT}
 
 ```
 HTTP/1.1 200 OK
-Server: nginx/1.15.4
+Server: nginx/1.21.6
 Date: Sun, 30 Sep 2018 19:25:40 GMT
 Content-Type: text/html
 Content-Length: 612
@@ -264,7 +264,7 @@ INSTANCE_NAME=$(kubectl get pod untrusted --output=jsonpath='{.spec.nodeName}')
 SSH into the worker node:
 
 ```
-EXTERNAL_IP=$(az vm show --show-details -g kubernetes-the-hard-way -n ${INSTANCE_NAME} --query publicIps --output tsv)
+EXTERNAL_IP=$(az vm show --show-details -g k8s-the-hard-way -n ${INSTANCE_NAME} --query publicIps --output tsv)
 ssh azureuser@${EXTERNAL_IP} 
 ```
 

--- a/docs/14-cleanup.md
+++ b/docs/14-cleanup.md
@@ -1,15 +1,15 @@
 # Cleaning Up
 
-In this lab you will delete the compute resources created during this tutorial. Everything you created belongs to the `kubernetes-the-hard-way` resource group, so cleaning everything up is as simple as deleteing the resource group:
+In this lab you will delete the compute resources created during this tutorial. Everything you created belongs to the `k8s-the-hard-way` resource group, so cleaning everything up is as simple as deleteing the resource group:
 
 ```
-az group delete --name kubernetes-the-hard-way --no-wait --yes
+az group delete --name k8s-the-hard-way --no-wait --yes
 ```
 
 This operation may take a while, periodically check to make sure everything was deleted:
 
 ```
-az group exists --name kubernetes-the-hard-way
+az group exists --name k8s-the-hard-way
 ```
 
 


### PR DESCRIPTION
I have been having issues with part 08 onwards with authentication issues. I found that most of the flags are either deprecated or renamed, so I had to make changes to get them up to date. Other changes include

- Configure certificate authority to have an expanded list of hostnames, instead of only kubernetes.default (taken from [kelseyhightower's version](https://github.com/kelseyhightower/kubernetes-the-hard-way/blob/master/docs/04-certificate-authority.md#the-kubernetes-api-server-certificate) ). Without this, the controller would get authentication errors when trying to create the coredns deployment
- Update versions of various tools. Not necessarily required, but I attempted to update versions with what is on kelseyhightower
- Update the name of the resource group to k8s-the-hard-way to match the beginning chapters
- Section 13, smoke test, created a pod, not a deployment which caused an error later in the doc. Updating to deployment fixed the issue

There is a [section in part 8](https://github.com/salaxander/kubernetes-the-hard-way/compare/master...kingan1:controller_fixes?expand=1#diff-554a1b07d1b7b0f44a70f90dd65ff5f45602103e473419feb831f3475917ddc7R63) where we need to access the KUBERNETES_PUBLIC_ADDRESS on the controller nodes. Currently, it requires installing the azure cli tool on each controller and logging in on each. There should be an easier way to do that, so this section is still unfinished/up for discussion. 