### PR TITLE
update k8s to 1.26.2

### DIFF
--- a/docs/07-bootstrapping-etcd.md
+++ b/docs/07-bootstrapping-etcd.md
@@ -22,14 +22,14 @@ Download the official etcd release binaries from the [coreos/etcd](https://githu
 
 ```
 wget -q --show-progress --https-only --timestamping \
-  "https://github.com/etcd-io/etcd/releases/download/v3.5.4/etcd-v3.5.4-linux-amd64.tar.gz"
+  "https://github.com/etcd-io/etcd/releases/download/v3.5.7/etcd-v3.5.7-linux-amd64.tar.gz"
 ```
 
 Extract and install the `etcd` server and the `etcdctl` command line utility:
 
 ```
-tar -xvf etcd-v3.5.4-linux-amd64.tar.gz
-sudo mv etcd-v3.5.4-linux-amd64/etcd* /usr/local/bin/
+tar -xvf etcd-v3.5.7-linux-amd64.tar.gz
+sudo mv etcd-v3.5.7-linux-amd64/etcd* /usr/local/bin/
 ```
 
 ### Configure the etcd Server

--- a/docs/08-bootstrapping-kubernetes-controllers.md
+++ b/docs/08-bootstrapping-kubernetes-controllers.md
@@ -28,10 +28,10 @@ Download the official Kubernetes release binaries:
 
 ```
 wget -q --show-progress --https-only --timestamping \
-  "https://dl.k8s.io/v1.24.1/bin/linux/amd64/kube-apiserver" \
-  "https://dl.k8s.io/v1.24.1/bin/linux/amd64/kube-controller-manager" \
-  "https://dl.k8s.io/v1.24.1/bin/linux/amd64/kube-scheduler" \
-  "https://dl.k8s.io/release/v1.24.1/bin/linux/amd64/kubectl"
+  "https://dl.k8s.io/v1.26.2/bin/linux/amd64/kube-apiserver" \
+  "https://dl.k8s.io/v1.26.2/bin/linux/amd64/kube-controller-manager" \
+  "https://dl.k8s.io/v1.26.2/bin/linux/amd64/kube-scheduler" \
+  "https://dl.k8s.io/release/v1.26.2/bin/linux/amd64/kubectl"
 ```
 
 Install the Kubernetes binaries:

--- a/docs/09-bootstrapping-kubernetes-workers.md
+++ b/docs/09-bootstrapping-kubernetes-workers.md
@@ -29,14 +29,14 @@ sudo apt-get -y install socat conntrack ipset
 
 ```
 wget -q --show-progress --https-only --timestamping \
-  https://github.com/kubernetes-sigs/cri-tools/releases/download/v1.24.0/crictl-v1.24.0-linux-amd64.tar.gz \
+  https://github.com/kubernetes-sigs/cri-tools/releases/download/v1.26.0/crictl-v1.26.0-linux-amd64.tar.gz \
   https://storage.googleapis.com/kubernetes-the-hard-way/runsc-50c283b9f56bb7200938d9e207355f05f79f0d17 \
-  https://github.com/opencontainers/runc/releases/download/v1.0.0-rc93/runc.amd64 \
-  https://github.com/containernetworking/plugins/releases/download/v0.9.1/cni-plugins-linux-amd64-v0.9.1.tgz \
-  https://github.com/containerd/containerd/releases/download/v1.4.4/containerd-1.4.4-linux-amd64.tar.gz \
-  https://storage.googleapis.com/kubernetes-release/release/v1.24.0/bin/linux/amd64/kubectl \
-  https://storage.googleapis.com/kubernetes-release/release/v1.24.0/bin/linux/amd64/kube-proxy \
-  https://storage.googleapis.com/kubernetes-release/release/v1.24.0/bin/linux/amd64/kubelet
+  https://github.com/opencontainers/runc/releases/download/v1.1.4/runc.amd64 \
+  https://github.com/containernetworking/plugins/releases/download/v1.2.0/cni-plugins-linux-amd64-v1.2.0.tgz \
+  https://github.com/containerd/containerd/releases/download/v1.6.19/containerd-1.6.19-linux-amd64.tar.gz \
+  https://storage.googleapis.com/kubernetes-release/release/v1.26.2/bin/linux/amd64/kubectl \
+  https://storage.googleapis.com/kubernetes-release/release/v1.26.2/bin/linux/amd64/kube-proxy \
+  https://storage.googleapis.com/kubernetes-release/release/v1.26.2/bin/linux/amd64/kubelet
 ```
 
 Create the installation directories:
@@ -58,9 +58,9 @@ sudo mv runsc-50c283b9f56bb7200938d9e207355f05f79f0d17 runsc
 sudo mv runc.amd64 runc
 chmod +x kubectl kube-proxy kubelet runc runsc
 sudo mv kubectl kube-proxy kubelet runc runsc /usr/local/bin/
-sudo tar -xvf crictl-v1.24.0-linux-amd64.tar.gz -C /usr/local/bin/
-sudo tar -xvf cni-plugins-linux-amd64-v0.9.1.tgz -C /opt/cni/bin/
-sudo tar -xvf containerd-1.4.4-linux-amd64.tar.gz -C /
+sudo tar -xvf crictl-v1.26.0-linux-amd64.tar.gz -C /usr/local/bin/
+sudo tar -xvf cni-plugins-linux-amd64-v1.2.0.tgz -C /opt/cni/bin/
+sudo tar -xvf containerd-1.6.19-linux-amd64.tar.gz -C /
 ```
 
 ### Configure CNI Networking
@@ -286,9 +286,9 @@ kubectl get nodes --kubeconfig admin.kubeconfig
 
 ```
 NAME       STATUS   ROLES    AGE   VERSION
-worker-0   Ready    <none>   35s   v1.12.0
-worker-1   Ready    <none>   36s   v1.12.0
-worker-2   Ready    <none>   36s   v1.12.0
+worker-0   Ready    <none>   35s   v1.26.2
+worker-1   Ready    <none>   36s   v1.26.2
+worker-2   Ready    <none>   36s   v1.26.2
 ```
 
 Next: [Configuring kubectl for Remote Access](10-configuring-kubectl.md)


### PR DESCRIPTION
Update etcd, Kubernetes, containerd, crictl, and cniplugins to latest versions available